### PR TITLE
Codex/portfolio sync main

### DIFF
--- a/scripts/portfolio/sync_github_portfolio_issues.py
+++ b/scripts/portfolio/sync_github_portfolio_issues.py
@@ -435,15 +435,28 @@ def main() -> int:
             gh.ensure_label(label, color)
 
     existing = gh.list_managed_issues()
-    index: Dict[str, dict] = {}
+    by_key: Dict[str, List[dict]] = {}
+    keyless_issues: List[dict] = []
     for issue in existing:
         key = _extract_key(issue.get("body", ""))
-        if key:
-            index[key] = issue
+        if not key:
+            keyless_issues.append(issue)
+            continue
+        by_key.setdefault(key, []).append(issue)
+
+    # Keep exactly one canonical issue per key: highest issue number.
+    index: Dict[str, dict] = {}
+    duplicate_issues: List[dict] = []
+    for key, issues_for_key in by_key.items():
+        sorted_for_key = sorted(issues_for_key, key=lambda it: it.get("number", 0), reverse=True)
+        index[key] = sorted_for_key[0]
+        duplicate_issues.extend(sorted_for_key[1:])
 
     created = 0
     updated = 0
     closed_stale = 0
+    closed_duplicates = 0
+    closed_keyless = 0
     desired_keys = {item.key for item in items}
     for item in items:
         current = index.get(item.key)
@@ -464,6 +477,30 @@ def main() -> int:
         updated += 1
 
     if args.close_stale:
+        # Close duplicate issues first (same key).
+        for dup in duplicate_issues:
+            dup_number = dup["number"]
+            dup_state = dup.get("state", "open")
+            if dup_state == "closed":
+                continue
+            if args.dry_run:
+                print(f"[dry-run] close duplicate issue #{dup_number} (same portfolio_key)")
+            else:
+                gh.close_issue(dup_number)
+            closed_duplicates += 1
+
+        # Close keyless managed issues (orphaned legacy cards).
+        for keyless in keyless_issues:
+            keyless_number = keyless["number"]
+            keyless_state = keyless.get("state", "open")
+            if keyless_state == "closed":
+                continue
+            if args.dry_run:
+                print(f"[dry-run] close keyless managed issue #{keyless_number} (missing portfolio_key)")
+            else:
+                gh.close_issue(keyless_number)
+            closed_keyless += 1
+
         for stale_key, stale_issue in index.items():
             if stale_key in desired_keys:
                 continue
@@ -479,7 +516,9 @@ def main() -> int:
 
     print(
         "Portfolio sync completed: "
-        f"scope={args.scope}, created={created}, updated={updated}, closed_stale={closed_stale}, total={len(items)}"
+        f"scope={args.scope}, created={created}, updated={updated}, "
+        f"closed_duplicates={closed_duplicates}, closed_keyless={closed_keyless}, "
+        f"closed_stale={closed_stale}, total={len(items)}"
     )
     return 0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Writes and optionally closes GitHub Issues/labels automatically, so mis-parsing or rule mistakes could create churn or close the wrong managed issues; changes are otherwise isolated to a new workflow and scripts.
> 
> **Overview**
> Adds an automated **portfolio snapshot + issue sync** pipeline driven by canonical governance markdown.
> 
> Introduces a new GitHub Action (`portfolio-auto-sync.yml`) that (1) validates and publishes a generated snapshot (`portfolio_snapshot.json`/`.md`) on PRs and relevant pushes, and (2) on `workflow_dispatch`/`phoenix-dev`/default-branch pushes upserts GitHub Issues from that snapshot with optional stale/duplicate cleanup.
> 
> Adds two Python scripts: `build_portfolio_snapshot.py` to parse the SSOT tables and enforce consistency rules (uniqueness/required fields and WSM↔registry contracts), and `sync_github_portfolio_issues.py` to create/update/close managed issues with deterministic keys, hierarchy-ordered titles, and auto-managed labels/statuses. Documentation in `portfolio_project/README.md` describes the SSOT model, triggers, and operational policy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f554cd47f1643d44908d3561acb330bf221bd9c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->